### PR TITLE
Redirect user to /feed after login if they have a profile

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -49,7 +49,7 @@ export const login = (email, password) => async (dispatch) => {
 
         dispatch({ type: IS_LOADING, payload: false });
 
-        if (response.data.profile !== null && response.data.profile._id) dispatch({ type: REDIRECT_STATUS, payload: '/' })
+        if (response.data.profile !== null && response.data.profile._id) dispatch({ type: REDIRECT_STATUS, payload: '/feed' })
         else dispatch({ type: REDIRECT_STATUS, payload: '/change-profile' })
 
     } catch (error) {


### PR DESCRIPTION
## Description

- This changes the redirect to /feed when a user logs in, that already has a profile created.
- One line of code change.

- Does not address an issue.


