### PR TITLE
Set the initial state of useStatus to false.

### DIFF
--- a/client/src/lib/hooks/useStatus.js
+++ b/client/src/lib/hooks/useStatus.js
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux'
 import { history } from '../history'
 
 export default function useStatus() {
-    const [status, setStatus] = useState(true);
+    const [status, setStatus] = useState(false);
     const isMounted = useRef(true)
     const { auth } = useSelector(state => state)
     const dispatch = useDispatch()


### PR DESCRIPTION
## Description

- Fixed a bug where the the navbar is already authenticated before login.

- Addresses issue #118 


