### PR TITLE
Login to Feed Transition Bugfix

### DIFF
--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -42,7 +42,7 @@ export const login = (email, password) => async (dispatch) => {
         }
 
         dispatch({ type: IS_LOADING, payload: false });
-
+        dispatch({type: REQUEST_SUCCESS, payload: true})
         if (response.data.profile !== null && response.data.profile._id) dispatch({ type: REDIRECT_STATUS, payload: '/feed' })
         else dispatch({ type: REDIRECT_STATUS, payload: '/change-profile' })
 

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -41,10 +41,10 @@ export const login = (email, password) => async (dispatch) => {
             });
         }
 
-        dispatch({ type: IS_LOADING, payload: false });
-        dispatch({type: REQUEST_SUCCESS, payload: true})
+        dispatch({ type: IS_LOADING, payload: false })
         if (response.data.profile !== null && response.data.profile._id) dispatch({ type: REDIRECT_STATUS, payload: '/feed' })
         else dispatch({ type: REDIRECT_STATUS, payload: '/change-profile' })
+        dispatch({type: REQUEST_SUCCESS, payload: {msg: "Login success!"}})
 
     } catch (error) {
         dispatch({ type: REQUEST_ERROR,

--- a/client/src/components/LoginAndReg/Login.js
+++ b/client/src/components/LoginAndReg/Login.js
@@ -13,8 +13,8 @@ const Login = (props) => {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
-  const [success, setSuccess] = React.useState(false);
-  const [msg, setMsg] = React.useState('');
+  const [success, setSuccess] = useState(false);
+  const [msg, setMsg] = useState('');
   const { request_error } = useSelector(state => state.network);
 
   useEffect(() => {
@@ -22,7 +22,11 @@ const Login = (props) => {
       setMsg(request_error.error)
       setError(true);
     }
-  }, [])
+    else {
+      setMsg('');
+      setError(false);
+    }
+  }, [request_error])
 
   function validateForm (props) {
     return email.length > 0 && password.length > 5

--- a/client/src/components/LoginAndReg/Login.js
+++ b/client/src/components/LoginAndReg/Login.js
@@ -22,10 +22,6 @@ const Login = (props) => {
       setMsg(request_error.error)
       setError(true);
     }
-    else {
-      setMsg('');
-      setError(false);
-    }
   }, [request_error])
 
   function validateForm (props) {

--- a/client/src/components/LoginAndReg/__tests__/login.js
+++ b/client/src/components/LoginAndReg/__tests__/login.js
@@ -114,12 +114,12 @@ describe('Login React-Redux Component', () => {
             }
             },
             { type: 'IS_LOADING', payload: false },
-            { type: 'REDIRECT_STATUS', payload: '/change-profile' }
+            { type: 'REDIRECT_STATUS', payload: '/change-profile' },
+            { type: 'REQUEST_SUCCESS', payload: {msg: "Login success!"}}
         ];
 
         // check individual parts of actions
         const actions = store.getActions();
-
         // check first action
         expect(actions[0]).toEqual(expectedActions[0]);
 
@@ -134,6 +134,7 @@ describe('Login React-Redux Component', () => {
         // check last two actions
         expect(actions[2]).toEqual(expectedActions[2]);
         expect(actions[3]).toEqual(expectedActions[3]);
+        expect(actions[4]).toEqual(expectedActions[4]);
     });
 
     // TEST CASE 2: Successful login WITh profile
@@ -209,7 +210,8 @@ describe('Login React-Redux Component', () => {
             }
             },
             { type: 'IS_LOADING', payload: false },
-            { type: 'REDIRECT_STATUS', payload: '/feed' } // redirect to feed instead
+            { type: 'REDIRECT_STATUS', payload: '/feed' }, // redirect to feed instead
+            { type: 'REQUEST_SUCCESS', payload: {msg: "Login success!"}}
         ];
 
         // check individual parts of actions

--- a/client/src/reducers/networkReducer.js
+++ b/client/src/reducers/networkReducer.js
@@ -19,7 +19,7 @@ import {
             case REQUEST_ERROR:
                 return { ...state, request_error: action.payload }
             case REQUEST_SUCCESS:
-                return { ...state, request_success: action.payload }
+                return { ...state, request_success: action.payload, request_error: null }
            default:
                return state;
        }


### PR DESCRIPTION

## Description

- Bug:  Feed page displays an error on successful login.
- Replicate:  Perform an invalid login, then perform a valid login.

-Solution:  Dispatched REQUEST_SUCCESS in Login action.  Added and initialized to null the request_error field to REQUEST_SUCCESS's returned object defined in networkReducer.js

- No issue created for bug


